### PR TITLE
Move CI to 5.3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         os:
           - ubuntu-latest
         ocaml-compiler:
-          - 5.2.0
+          - 5.3.0
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
CI is mysteriously breaking on a package that no longer exists. Just seeing if it's compiler version related.